### PR TITLE
TemporaryStructure: Fix readability with dark themes

### DIFF
--- a/HexRaysPyTools/Core/TemporaryStructure.py
+++ b/HexRaysPyTools/Core/TemporaryStructure.py
@@ -520,6 +520,9 @@ class TemporaryStructureModel(QtCore.QAbstractTableModel):
                     return QtGui.QBrush(QtGui.QColor("#ff8080"))
             if self.have_collision(row):
                 return QtGui.QBrush(QtGui.QColor("#ffff99"))
+        elif role == QtCore.Qt.ForegroundRole:
+            if self.have_collision(row):
+                return QtGui.QBrush(QtGui.QColor("#191919"))
 
     def setData(self, index, value, role):
         row, col = index.row(), index.column()

--- a/HexRaysPyTools/Core/TemporaryStructure.py
+++ b/HexRaysPyTools/Core/TemporaryStructure.py
@@ -512,7 +512,7 @@ class TemporaryStructureModel(QtCore.QAbstractTableModel):
         elif role == QtCore.Qt.FontRole:
             if col == 1:
                 return item.font
-        elif role == QtCore.Qt.BackgroundColorRole:
+        elif role == QtCore.Qt.BackgroundRole:
             if not item.enabled:
                 return QtGui.QColor(QtCore.Qt.gray)
             if item.offset == self.main_offset:


### PR DESCRIPTION
When a dark theme is used, the bright yellow background color makes the
white/light gray text completely unreadable.

This commit fixes that problem by not assuming the default text color
is a dark color and instead manually setting the text color to black.