### PR TITLE
Fix  demangle/decompile errors from unusual data

### DIFF
--- a/HexRaysPyTools/core/temporary_structure.py
+++ b/HexRaysPyTools/core/temporary_structure.py
@@ -34,7 +34,7 @@ def parse_vtable_name(address):
             return name, True
         print "[Warning] Weird virtual table name -", name
         return "Vtable_" + name, False
-    name = idc.demangle_name(idaapi.get_name(address), idc.INF_SHORT_DN)
+    name = idc.demangle_name(idaapi.get_name(address), idc.get_inf_attr(idc.INF_SHORT_DN))
     assert name, "Virtual table must have either legal c-type name or mangled name"
     return common.demangled_name_to_c_str(name), True
 
@@ -147,7 +147,7 @@ class VirtualFunction:
         name = idaapi.get_name(self.address)
         if idaapi.is_valid_typename(name):
             return name
-        name = idc.Demangle(name, idc.INF_SHORT_DN)
+        name = idc.Demangle(name, idc.get_inf_attr(idc.INF_SHORT_DN))
         return common.demangled_name_to_c_str(name)
 
     @property

--- a/HexRaysPyTools/core/temporary_structure.py
+++ b/HexRaysPyTools/core/temporary_structure.py
@@ -154,7 +154,7 @@ class VirtualFunction:
     def tinfo(self):
         try:
             decompiled_function = idaapi.decompile(self.address)
-            if decompiled_function:
+            if decompiled_function and decompiled_function.type:
                 return idaapi.tinfo_t(decompiled_function.type)
             return const.DUMMY_FUNC
         except idaapi.DecompilationFailure:


### PR DESCRIPTION
This comprises of two fixes.

### Demangle names
I hit this issue when the program appeared to have two vtables with the same name. The first demangled perfectly, but the second resulted in `None` without using the recommended way of passing the mask.
```
??_7World@@6B@   => const World::`vftable'
??_7World@@6B@_0 => const World::`vftable'
```

### Decompiled Function Type
Here I hit a function that was successfully decompiled, but had a type of `None`, which was then passed to `tinfo_t`, resulting in a a `ValueError`.
I can try and provide an example if required.