### PR TITLE
fix py3 bug I was running into

### DIFF
--- a/HexRaysPyTools/core/helper.py
+++ b/HexRaysPyTools/core/helper.py
@@ -338,8 +338,7 @@ def load_long_str_from_idb(array_name):
         return None
     max_idx = idc.get_last_index(idc.AR_STR, id)
     result = [idc.get_array_element(idc.AR_STR, id, idx) for idx in range(max_idx + 1)]
-    return "".join(result)
-
+    return b"".join(result).decode("utf-8")
 
 def create_padding_udt_member(offset, size):
     # type: (long, long) -> idaapi.udt_member_t


### PR DESCRIPTION
When I loaded an idb I would get a pop-up exception because the `result` list contained bytes, not strings, so this fixes that in my case at least. 

![2019-11-12-185335_772x200_scrot](https://user-images.githubusercontent.com/13679876/68675656-4c7fd980-0593-11ea-9a3d-152a7b4e4154.png)
