### PR TITLE
Add literal operator to demangled_name_to_c_str

### DIFF
--- a/HexRaysPyTools/core/common.py
+++ b/HexRaysPyTools/core/common.py
@@ -96,6 +96,8 @@ def demangled_name_to_c_str(name):
             name = name.replace("operator new", "operator_NEW_")
         elif name[idx: idx + 7] == " delete":
             name = name.replace("operator delete", "operator_DELETE_")
+        elif name[idx:idx + 2] == "\"\" ":
+            name = name.replace("operator\"\" ", "operator_LITERAL_")
         elif name[idx] == ' ':
             pass
         else:


### PR DESCRIPTION
I add a new rule to work with `operator"" ???` case,
for my case, it's `nghttp2::operator"" _k(unsigned long long)`

reference (since C++11): 
https://en.cppreference.com/w/cpp/language/user_literal