### PR TITLE
Fix 'Structures with this size' for numbers >= 0x40

### DIFF
--- a/HexRaysPyTools/callbacks/structs_by_size.py
+++ b/HexRaysPyTools/callbacks/structs_by_size.py
@@ -57,7 +57,7 @@ class GetStructureBySize(actions.HexRaysPopupAction):
             operand_number = number_format_old.opnum
             number_format_new.opnum = operand_number
             number_format_new.props = number_format_old.props
-            number_format_new.type_name = idaapi.create_numbered_type_name(ordinal)
+            number_format_new.type_name = idaapi.get_numbered_type_name(idaapi.cvar.idati, ordinal)
 
             c_function = hx_view.cfunc
             number_formats = c_function.numforms    # type: idaapi.user_numforms_t


### PR DESCRIPTION
```
Python>print(idaapi.create_numbered_type_name(0x40))
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "C:\Program Files\IDA Pro\python\3\ida_typeinf.py", line 4199, in create_numbered_type_name
    return _ida_typeinf.create_numbered_type_name(*args)
UnicodeDecodeError: 'utf-8' codec can't decode byte 0x81 in position 1: invalid start byte
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "C:\Program Files\IDA Pro\python\3\ida_typeinf.py", line 4199, in create_numbered_type_name
    return _ida_typeinf.create_numbered_type_name(*args)
UnicodeDecodeError: 'utf-8' codec can't decode byte 0x81 in position 1: invalid start byte
```
This bug comes from IDAPython for Python 3, as I see it. I am not sure that using `get_numbered_type_name` is identical, but in my testing this works as expected.