### PR TITLE
Helper.py: Fix error when get_array_element returns an int.

### DIFF
--- a/HexRaysPyTools/callbacks/negative_offsets.py
+++ b/HexRaysPyTools/callbacks/negative_offsets.py
@@ -25,7 +25,7 @@ def _parse_magic_comment(lvar):
             structure_name, offset = m.group(1).split('+')
             offset = int(offset)
             parent_tinfo = idaapi.tinfo_t()
-            if parent_tinfo.get_named_type(idaapi.cvar.idati, structure_name) and parent_tinfo.get_size() > offset:
+            if parent_tinfo.get_named_type(idaapi.get_idati(), structure_name) and parent_tinfo.get_size() > offset:
                 member_name = dict(find_deep_members(parent_tinfo, lvar.type().get_pointed_object())).get(offset, None)
                 if member_name:
                     return NegativeLocalInfo(lvar.type().get_pointed_object(), parent_tinfo, offset, member_name)
@@ -220,7 +220,7 @@ class SearchVisitor(idaapi.ctree_parentee_t):
                         parent_name = expression.a[1].helper
                         member_name = expression.a[2].helper
                         parent_tinfo = idaapi.tinfo_t()
-                        if not parent_tinfo.get_named_type(idaapi.cvar.idati, parent_name):
+                        if not parent_tinfo.get_named_type(idaapi.get_idati(), parent_name):
                             return 0
                         udt_data = idaapi.udt_type_data_t()
                         parent_tinfo.get_udt_details(udt_data)

--- a/HexRaysPyTools/callbacks/new_field_creation.py
+++ b/HexRaysPyTools/callbacks/new_field_creation.py
@@ -105,7 +105,7 @@ class CreateNewField(actions.HexRaysPopupAction):
             udt_data.insert(iterator, helper.create_padding_udt_member(offset, idx))
 
         struct_tinfo.create_udt(udt_data, idaapi.BTF_STRUCT)
-        struct_tinfo.set_numbered_type(idaapi.cvar.idati, ordinal, idaapi.BTF_STRUCT, struct_name)
+        struct_tinfo.set_numbered_type(idaapi.get_idati(), ordinal, idaapi.BTF_STRUCT, struct_name)
         hx_view.refresh_view(True)
 
     @staticmethod
@@ -127,7 +127,7 @@ class CreateNewField(actions.HexRaysPopupAction):
 
         _, tp, fld = result
         tinfo = idaapi.tinfo_t()
-        tinfo.deserialize(idaapi.cvar.idati, tp, fld, None)
+        tinfo.deserialize(idaapi.get_idati(), tp, fld, None)
         if arr_size:
             assert tinfo.create_array(tinfo, int(arr_size))
         return tinfo, field_name

--- a/HexRaysPyTools/callbacks/recasts.py
+++ b/HexRaysPyTools/callbacks/recasts.py
@@ -179,8 +179,8 @@ class RecastItemLeft(actions.HexRaysPopupAction):
 
         elif isinstance(ri, RecastStructure):
             tinfo = idaapi.tinfo_t()
-            tinfo.get_named_type(idaapi.cvar.idati, ri.structure_name)
-            ordinal = idaapi.get_type_ordinal(idaapi.cvar.idati, ri.structure_name)
+            tinfo.get_named_type(idaapi.get_idati(), ri.structure_name)
+            ordinal = idaapi.get_type_ordinal(idaapi.get_idati(), ri.structure_name)
             if ordinal == 0:
                 return 0
 
@@ -196,7 +196,7 @@ class RecastItemLeft(actions.HexRaysPopupAction):
                 tinfo.get_udt_details(udt_data)
                 udt_data[idx].type = ri.recast_tinfo
                 tinfo.create_udt(udt_data, idaapi.BTF_STRUCT)
-                tinfo.set_numbered_type(idaapi.cvar.idati, ordinal, idaapi.NTF_REPLACE, ri.structure_name)
+                tinfo.set_numbered_type(idaapi.get_idati(), ordinal, idaapi.NTF_REPLACE, ri.structure_name)
         else:
             raise NotImplementedError
 

--- a/HexRaysPyTools/callbacks/scanners.py
+++ b/HexRaysPyTools/callbacks/scanners.py
@@ -127,7 +127,7 @@ class DeepScanFunctions(actions.Action):
                 NewDeepSearchVisitor(cfunc, 0, obj, cache.temporary_structure).process()
 
     def update(self, ctx):
-        if ctx.form_type == idaapi.BWN_FUNCS:
+        if ctx.widget_type == idaapi.BWN_FUNCS:
             idaapi.attach_action_to_popup(ctx.widget, None, self.name)
             return idaapi.AST_ENABLE_FOR_WIDGET
         return idaapi.AST_DISABLE_FOR_WIDGET

--- a/HexRaysPyTools/callbacks/structs_by_size.py
+++ b/HexRaysPyTools/callbacks/structs_by_size.py
@@ -57,7 +57,7 @@ class GetStructureBySize(actions.HexRaysPopupAction):
             operand_number = number_format_old.opnum
             number_format_new.opnum = operand_number
             number_format_new.props = number_format_old.props
-            number_format_new.type_name = idaapi.get_numbered_type_name(idaapi.cvar.idati, ordinal)
+            number_format_new.type_name = idaapi.get_numbered_type_name(idaapi.get_idati(), ordinal)
 
             c_function = hx_view.cfunc
             number_formats = c_function.numforms    # type: idaapi.user_numforms_t

--- a/HexRaysPyTools/core/classes.py
+++ b/HexRaysPyTools/core/classes.py
@@ -65,7 +65,7 @@ class VirtualMethod(object):
             split = value.split('(')
             if len(split) == 2:
                 value = split[0] + ' ' + self.name + '(' + split[1] + ';'
-                if idaapi.parse_decl(tinfo, idaapi.cvar.idati, value, idaapi.PT_TYP) is not None:
+                if idaapi.parse_decl(tinfo, idaapi.get_idati(), value, idaapi.PT_TYP) is not None:
                     if tinfo.is_func():
                         tinfo.create_ptr(tinfo)
                         if tinfo.dstr() != self.tinfo.dstr():
@@ -110,7 +110,7 @@ class VirtualMethod(object):
         func_tinfo = self.tinfo.get_pointed_object()
         class_tinfo = idaapi.tinfo_t()
         if func_tinfo.get_func_details(func_data) and func_tinfo.get_nargs() and \
-                class_tinfo.get_named_type(idaapi.cvar.idati, name):
+                class_tinfo.get_named_type(idaapi.get_idati(), name):
             class_tinfo.create_ptr(class_tinfo)
             first_arg_tinfo = func_data[0].type
             if (first_arg_tinfo.is_ptr() and first_arg_tinfo.get_pointed_object().is_udt()) or \
@@ -175,7 +175,7 @@ class VirtualTable(object):
         if self.modified:
             vtable_tinfo = idaapi.tinfo_t()
             udt_data = idaapi.udt_type_data_t()
-            vtable_tinfo.get_numbered_type(idaapi.cvar.idati, self.ordinal)
+            vtable_tinfo.get_numbered_type(idaapi.get_idati(), self.ordinal)
             vtable_tinfo.get_udt_details(udt_data)
             self.tinfo = vtable_tinfo
             self.name = vtable_tinfo.dstr()
@@ -197,7 +197,7 @@ class VirtualTable(object):
                     udt_member.type = virtual_function.tinfo
                     virtual_function.commit()
                 final_tinfo.create_udt(udt_data, idaapi.BTF_STRUCT)
-                final_tinfo.set_numbered_type(idaapi.cvar.idati, self.ordinal, idaapi.NTF_REPLACE, self.name)
+                final_tinfo.set_numbered_type(idaapi.get_idati(), self.ordinal, idaapi.NTF_REPLACE, self.name)
                 self.modified = False
             else:
                 print("[ERROR] Something have been modified in Local types. Please refresh this view")
@@ -219,11 +219,11 @@ class VirtualTable(object):
 
     @staticmethod
     def create(tinfo, class_):
-        ordinal = idaapi.get_type_ordinal(idaapi.cvar.idati, tinfo.dstr())
+        ordinal = idaapi.get_type_ordinal(idaapi.get_idati(), tinfo.dstr())
         if ordinal == 0:
-            if idaapi.import_type(idaapi.cvar.idati, -1, tinfo.dstr(), 0) == idaapi.BADNODE:
+            if idc.import_type(-1, tinfo.dstr()) == idaapi.BADNODE:
                 raise ImportError("unable to import type to idb ({})".format(tinfo.dstr()))
-            ordinal = idaapi.get_type_ordinal(idaapi.cvar.idati, tinfo.dstr())
+            ordinal = idaapi.get_type_ordinal(idaapi.get_idati(), tinfo.dstr())
 
         result = all_virtual_tables.get(ordinal)
         if result:
@@ -291,7 +291,7 @@ class Class(object):
     @staticmethod
     def create_class(ordinal):
         tinfo = idaapi.tinfo_t()
-        tinfo.get_numbered_type(idaapi.cvar.idati, ordinal)
+        tinfo.get_numbered_type(idaapi.get_idati(), ordinal)
         vtables = {}
         if tinfo.is_struct():
             udt_data = idaapi.udt_type_data_t()
@@ -337,7 +337,7 @@ class Class(object):
             tinfo = idaapi.tinfo_t()
             self.tinfo.get_udt_details(udt_data)
             tinfo.create_udt(udt_data, idaapi.BTF_STRUCT)
-            tinfo.set_numbered_type(idaapi.cvar.idati, self.ordinal, idaapi.NTF_REPLACE, self.name)
+            tinfo.set_numbered_type(idaapi.get_idati(), self.ordinal, idaapi.NTF_REPLACE, self.name)
             self.modified = False
 
     def set_first_argument_type(self, class_name):
@@ -388,7 +388,7 @@ class Class(object):
     @property
     def tinfo(self):
         tinfo = idaapi.tinfo_t()
-        tinfo.get_numbered_type(idaapi.cvar.idati, self.ordinal)
+        tinfo.get_numbered_type(idaapi.get_idati(), self.ordinal)
         return tinfo
 
     def open_function(self):
@@ -450,7 +450,7 @@ class TreeModel(QtCore.QAbstractItemModel):
         all_virtual_tables.clear()
 
         classes = []
-        for ordinal in range(1, idaapi.get_ordinal_qty(idaapi.cvar.idati)):
+        for ordinal in range(1, idaapi.get_ordinal_qty(idaapi.get_idati())):
             result = Class.create_class(ordinal)
             if result:
                 classes.append(result)

--- a/HexRaysPyTools/core/const.py
+++ b/HexRaysPyTools/core/const.py
@@ -33,7 +33,7 @@ def init():
         PX_WORD_TINFO, DUMMY_FUNC, CONST_PCHAR_TINFO, CHAR_TINFO, PCHAR_TINFO, CONST_VOID_TINFO, \
         WORD_TINFO, PWORD_TINFO, EA64, EA_SIZE
 
-    EA64 = idaapi.get_inf_structure().is_64bit()
+    EA64 = idaapi.inf_is_64bit()
     EA_SIZE = 8 if EA64 else 4
 
     VOID_TINFO = idaapi.tinfo_t(idaapi.BT_VOID)

--- a/HexRaysPyTools/core/helper.py
+++ b/HexRaysPyTools/core/helper.py
@@ -2,6 +2,7 @@ import collections
 import logging
 
 import idaapi
+import ida_ida
 import idc
 
 import HexRaysPyTools.core.cache as cache
@@ -20,7 +21,7 @@ def is_imported_ea(ea):
 
 
 def is_code_ea(ea):
-    if idaapi.cvar.inf.procname == "ARM":
+    if ida_ida.inf_get_procname() == "ARM":
         # In case of ARM code in THUMB mode we sometimes get pointers with thumb bit set
         flags = idaapi.get_full_flags(ea & -2)  # flags_t
     else:
@@ -38,7 +39,7 @@ def get_ptr(ea):
     if const.EA64:
         return idaapi.get_64bit(ea)
     ptr = idaapi.get_32bit(ea)
-    if idaapi.cvar.inf.procname == "ARM":
+    if ida_ida.inf_get_procname() == "ARM":
         ptr &= -2    # Clear thumb bit
     return ptr
 

--- a/HexRaysPyTools/core/helper.py
+++ b/HexRaysPyTools/core/helper.py
@@ -50,7 +50,7 @@ def get_ordinal(tinfo):
     if ordinal == 0:
         t = idaapi.tinfo_t()
         struct_name = tinfo.dstr().split()[-1]        # Get rid of `struct` prefix or something else
-        t.get_named_type(idaapi.cvar.idati, struct_name)
+        t.get_named_type(idaapi.get_idati(), struct_name)
         ordinal = t.get_ordinal()
     return ordinal
 
@@ -176,7 +176,7 @@ def get_nice_pointed_object(tinfo):
         name = tinfo.dstr()
         if name[0] == 'P':
             pointed_tinfo = idaapi.tinfo_t()
-            if pointed_tinfo.get_named_type(idaapi.cvar.idati, name[1:]):
+            if pointed_tinfo.get_named_type(idaapi.get_idati(), name[1:]):
                 if tinfo.get_pointed_object().equals_to(pointed_tinfo):
                     return pointed_tinfo
     except TypeError:
@@ -248,9 +248,9 @@ def import_structure(name, tinfo):
     if idc.parse_decl(cdecl_typedef, idaapi.PT_TYP) is None:
         return 0
 
-    previous_ordinal = idaapi.get_type_ordinal(idaapi.cvar.idati, name)
+    previous_ordinal = idaapi.get_type_ordinal(idaapi.get_idati(), name)
     if previous_ordinal:
-        idaapi.del_numbered_type(idaapi.cvar.idati, previous_ordinal)
+        idaapi.del_numbered_type(idaapi.get_idati(), previous_ordinal)
         ordinal = idaapi.idc_set_local_type(previous_ordinal, cdecl_typedef, idaapi.PT_TYP)
     else:
         ordinal = idaapi.idc_set_local_type(-1, cdecl_typedef, idaapi.PT_TYP)

--- a/HexRaysPyTools/core/helper.py
+++ b/HexRaysPyTools/core/helper.py
@@ -337,7 +337,12 @@ def load_long_str_from_idb(array_name):
     if id == -1:
         return None
     max_idx = idc.get_last_index(idc.AR_STR, id)
-    result = [idc.get_array_element(idc.AR_STR, id, idx) for idx in range(max_idx + 1)]
+    result = []
+    for idx in range(max_idx + 1):
+        e = idc.get_array_element(idc.AR_STR, id, idx)
+        if type(e) == int:
+            e = e.to_bytes((e.bit_length() + 7) // 8, 'little')
+        result.append(e)
     return b"".join(result).decode("utf-8")
 
 def create_padding_udt_member(offset, size):

--- a/HexRaysPyTools/core/structure_graph.py
+++ b/HexRaysPyTools/core/structure_graph.py
@@ -100,7 +100,7 @@ class StructureGraph:
         if local_typestring:
             p_type, fields = local_typestring
             local_tinfo = idaapi.tinfo_t()
-            local_tinfo.deserialize(idaapi.cvar.idati, p_type, fields)
+            local_tinfo.deserialize(idaapi.get_idati(), p_type, fields)
             return local_tinfo
         return None
 

--- a/HexRaysPyTools/core/type_library.py
+++ b/HexRaysPyTools/core/type_library.py
@@ -40,10 +40,10 @@ def choose_til():
     # type: () -> (idaapi.til_t, int, bool)
     """ Creates a list of loaded libraries, asks user to take one of them and returns it with
     information about max ordinal and whether it's local or imported library """
-    idati = idaapi.cvar.idati
+    idati = idaapi.get_idati()
     list_type_library = [(idati, idati.name, idati.desc)]
-    for idx in range(idaapi.cvar.idati.nbases):
-        type_library = idaapi.cvar.idati.base(idx)          # type: idaapi.til_t
+    for idx in range(idaapi.get_idati().nbases):
+        type_library = idaapi.get_idati().base(idx)          # type: idaapi.til_t
         list_type_library.append((type_library, type_library.name, type_library.desc))
 
     library_chooser = forms.MyChoose(
@@ -64,8 +64,8 @@ def choose_til():
 
 
 def import_type(library, name):
-    if library.name != idaapi.cvar.idati.name:
-        last_ordinal = idaapi.get_ordinal_qty(idaapi.cvar.idati)
-        type_id = idaapi.import_type(library, -1, name)  # tid_t
+    if library.name != idaapi.get_idati().name:
+        last_ordinal = idaapi.get_ordinal_qty(idaapi.get_idati())
+        type_id = library.import_type(name)
         if type_id != idaapi.BADORD:
             return last_ordinal

--- a/readme.md
+++ b/readme.md
@@ -18,7 +18,7 @@ About
 
 The plugin assists in the creation of classes/structures and detection of virtual tables. It also facilitates transforming decompiler output faster and allows to do some stuff which is otherwise impossible.
 
-**Note**: The plugin supports IDA Pro 7.x with Python 2/3.
+**Note**: The plugin supports IDA Pro 9.x with Python 3.
 
 Installation
 ============


### PR DESCRIPTION
When opening certain IDB's in IDA 7.5, I get the following error:
![2020-08-18 11_51_19-Warning](https://user-images.githubusercontent.com/13575362/90536398-01aa7800-e14a-11ea-880e-3e5d193ade90.png)

This error prevents the plugin from being loaded and messes up the `Structures` view. This is due to [get_array_element](https://www.hex-rays.com/products/ida/support/idapython_docs/idc-module.html#get_array_element) sometimes returning an integer.
This PR converts integers to bytes object in the `load_long_str_from_idb` helper function.